### PR TITLE
Support --kube-context parameter for helm ls

### DIFF
--- a/helm.js
+++ b/helm.js
@@ -78,6 +78,10 @@ module.exports = class Helm {
     //adding options variable empty for future use
     list(options, done){
         var command = ['list'];
+        if (options.kubeContext) {
+            command.push('--kube-context');
+            command.push(options.kubeContext);
+        }
         this.executer.callByArguments(command, callbackHandler(done, true), true);           
     }
 


### PR DESCRIPTION
This is necessary to run `helm ls` against a specific cluster.

@adibenmat Would it make sense to also add it to the other commands?