### PR TITLE
Support --output parameter for helm status

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ https://docs.helm.sh/helm/#helm-status
 ```    
     let options = {
         releaseName = 'service';
+        outputFormat = 'json'; // optional
     }
     let status = await helm.statusAsync(options);  
 ```

--- a/helm.js
+++ b/helm.js
@@ -121,6 +121,10 @@ module.exports = class Helm {
         if(options.releaseName == null){
             throw new Error("Missing parameter 'releaseName'");
         }          
+        if (options.outputFormat){
+            command.push('--output')
+            command.push(options.outputFormat)
+        }
         command.push(options.releaseName);      
         
         this.executeCommandByArguments(options, command, done);               


### PR DESCRIPTION
As per [documentation](https://helm.sh/docs/helm/helm_status/). I am adding the `--output` parameter for `helm status` so results could be easily parsed